### PR TITLE
Iss73 74 using workingdir

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -127,7 +127,7 @@ jobs:
       - name: Run Smoke Test
         run: |
           docker run -i --rm \
-            -v ${PWD}/test/smoke-test:/project \
+            --mount type=bind,src=${PWD}/test/smoke-test,dst=/project \
             ${{ inputs.image-name }}:${{ inputs.branch-name }} lint
 
       - name: Run Integration Tests

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -128,7 +128,6 @@ jobs:
         run: |
           docker run -i --rm \
             -v ${PWD}/test/smoke-test:/project \
-            -e PROJECT_PATH=/project \
             ${{ inputs.image-name }}:${{ inputs.branch-name }} lint
 
       - name: Run Integration Tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,12 +12,12 @@
 
 FROM node:22.14.0-alpine3.21
 
+# This creates /app and sets it as the working directory
+WORKDIR /app
+
 # Add the bp3 user and group - using 1001 because node's is already using 1000 - and install the Camunda lint global packages and create /app and set folder ownership
-RUN npm install -g bpmnlint@11.12.0 \
-                    dmnlint@0.2.0 && \
-    addgroup --gid 1001 bp3 && \
+RUN addgroup --gid 1001 bp3 && \
     adduser --uid 1001 --ingroup bp3 --home /home/bp3user --shell /bin/bash --disabled-password bp3user && \
-    mkdir /app  && \
     chown -R bp3user:bp3 /usr/local/lib/node_modules && \
     chown -R bp3user:bp3 /usr/local/bin && \
     chown -R bp3user:bp3 /app
@@ -28,8 +28,6 @@ COPY --chown=bp3user:bp3 --chmod=755 .npmrc /home/bp3user/.npmrc
 COPY --chown=bp3user:bp3 --chmod=755 ["docker-entrypoint.sh", "l*.js", "package*.js*", ".npmrc", "camunda-lint-sbom.json", "/app/" ]
 COPY --chown=bp3user:bp3 --chmod=755 bp3-dynamic-rules/ /app/bp3-dynamic-rules/
 
-WORKDIR /app
-
 # As this is now a node workspace, this installs all the dependencies for child folders also
 # NOTE: can only perform the installations for the @BP3/bpmnlint-plugin-bpmn-rules because it requires the steps above to be done
 RUN --mount=type=secret,id=GH_TOKEN,uid=1001 \
@@ -37,8 +35,7 @@ RUN --mount=type=secret,id=GH_TOKEN,uid=1001 \
     npm install @BP3/bpmnlint-plugin-bpmn-rules@latest && \
     npm install
 
-VOLUME /local
-WORKDIR /local
+WORKDIR /project
 
 ENTRYPOINT ["/app/docker-entrypoint.sh"]
 CMD ["help"]

--- a/lint-runner.js
+++ b/lint-runner.js
@@ -233,7 +233,7 @@ async function findFiles(pattern) {
 async function lintFiles(files, linter, linterType) {
   const allIssues = [];
   let totalErrors = 0;
-  let totalWarnings = 0;
+  let totalIssues = 0;
 
   const linterConfig = LINTER_CONFIGS[linterType];
   const moddle = linterConfig.getModdle();
@@ -257,7 +257,7 @@ async function lintFiles(files, linter, linterType) {
             category: 'import-warning',
             rule: moddleName,
           });
-          totalWarnings++;
+          totalIssues++;
         });
         if (Object.keys(report).length === 0) {
           logger.debug('  No issues found.');
@@ -270,8 +270,8 @@ async function lintFiles(files, linter, linterType) {
       Object.entries(report).forEach(([ruleName, issues]) => {
         issues.forEach((issue) => {
           logger.debug(`- [${issue.category}] (${ruleName}) ${issue.id || 'N/A'}: ${issue.message}`);
+          totalIssues++;
           if (issue.category?.toLowerCase().includes('error')) totalErrors++;
-          else totalWarnings++;
 
           allIssues.push({ file: fileName, rule: ruleName, ...issue });
         });
@@ -289,7 +289,7 @@ async function lintFiles(files, linter, linterType) {
     }
   }
 
-  return { allIssues, totalErrors, totalWarnings };
+  return { allIssues, totalErrors, totalWarnings: totalIssues };
 }
 
 function generateReport({ allIssues, totalErrors, totalWarnings }, lintedFiles, format, outputPath, showConsoleTable, linterType) {
@@ -306,12 +306,10 @@ function generateReport({ allIssues, totalErrors, totalWarnings }, lintedFiles, 
     allIssues.forEach((issue) => {
       //default to info if not specified
       const issueType = issue.category?.toLowerCase() || 'info';
-      const isError = issue.category?.toLowerCase().includes('error') || issue.severity === 'error';
-      //DEPRECATED: const label = isError ? theme.error : theme.warning;
+      const isError = issue.category === 'error' || issue.category?.toLowerCase().includes('error');
       const label = theme[issueType] || theme.info;
       const file = path.basename(issue.file);
       const output = isError ? totalErrors > 0 : totalErrors === 0;
-
       if (output) {
         reportDetails += `${label} ${chalk.cyan(file)} › ${issue.id || 'N/A'}: ${issue.message} ${chalk.gray(`(${issue.rule})`)}\n`;
       }
@@ -326,7 +324,10 @@ ${chalk.gray('-'.repeat(60))}
 ${chalk.bold('LINT RESULTS')} | Files: ${lintedFiles.length} | Errors: ${chalk.red.bold(totalErrors)} | Warnings: ${chalk.yellow.bold(totalWarnings)}`);
 
   const extension = format === 'junit' ? 'xml' : format;
-  const finalOutputPath = path.resolve(process.cwd(), `${outputPath}${outputPath.indexOf(linterType) < 0 ? `-${linterType}` : ``}${outputPath.indexOf(extension) < 0 ? `.${extension}` : ``}`);
+  const finalOutputPath = path.resolve(
+    process.cwd(),
+    `${outputPath}${outputPath.toLowerCase().indexOf(linterType) < 0 ? `-${linterType}` : ``}${outputPath.indexOf(extension) < 0 ? `.${extension}` : ``}`
+  );
   let reportContent;
 
   try {

--- a/lint.js
+++ b/lint.js
@@ -36,6 +36,7 @@ const BUNDLED_PLUGINS = ['@BP3/bpmnlint-plugin-bpmn-rules'];
 
 const LINTRC_REVISED_SUFFIX = 'Revised';
 
+const WORKING_DIR = process.cwd();
 const PACKAGE_JSON = 'package.json';
 const LINT_RUNNER_PATH = path.resolve(fs.existsSync('/app') ? '/app' : process.cwd(), `./`); // './lint-runner/'
 const SBOM_JSON_FILE = path.resolve(fs.existsSync('/app') ? '/app' : process.cwd(), `./camunda-lint-sbom.json`);
@@ -92,8 +93,8 @@ let isModeDmn = false;
 let isModeSbom = false;
 let isShowHelp = false;
 
-let bpmnPath = './';
-let dmnPath = './';
+// let bpmnPath = './';
+// let dmnPath = './';
 
 let modeArgument = null;
 let overallSuccess = true;
@@ -337,7 +338,7 @@ if (isModeSbom) {
 }
 
 if (isModeBpmn) {
-  const bpmnTarget = process.env.BPMN_PATH || process.env.PROJECT_PATH || bpmnPath;
+  const bpmnTarget = WORKING_DIR;
   logger.debug(`Running linter for ${BPMN} with path: ${bpmnTarget}`);
   if (!lint(BPMN, bpmnTarget)) {
     overallSuccess = false;
@@ -345,7 +346,7 @@ if (isModeBpmn) {
 }
 
 if (isModeDmn) {
-  const dmnTarget = process.env.DMN_PATH || process.env.PROJECT_PATH || dmnPath;
+  const dmnTarget = WORKING_DIR;
   logger.debug(`Running linter for ${DMN} with path: ${dmnTarget}`);
   if (!lint(DMN, dmnTarget)) {
     overallSuccess = false;

--- a/lint.js
+++ b/lint.js
@@ -250,6 +250,8 @@ function lint(linterType, projectPath) {
 
   if ((isBpmnLinterType && !isStringNullOrEmpty(process.env.BPMN_REPORT_FILEPATH)) || (!isBpmnLinterType && !isStringNullOrEmpty(process.env.DMN_REPORT_FILEPATH))) {
     linterArgs[argumentOutputPath] = isBpmnLinterType ? process.env.BPMN_REPORT_FILEPATH : process.env.DMN_REPORT_FILEPATH;
+  } else {
+    linterArgs[argumentOutputPath] = path.join(WORKING_DIR, `${isBpmnLinterType ? BPMN.toLowerCase() : DMN.toLowerCase()}-lint-report`);
   }
 
   linterArgs[argumentFormat] = process.env.REPORT_FORMAT || 'json';

--- a/test/integration/integration.spec.js
+++ b/test/integration/integration.spec.js
@@ -99,7 +99,7 @@ describe('Integration Tests', function () {
   // *****************************************************************
   // bpmnlint
   // *****************************************************************
-  performContainerTest('bpmnlint', { timeout: 30000, hasOutput: true }, 'bpmnlint', [`--mount type=bind,src=${__dirname},dst=/project`, '-e PROJECT_PATH=/project'], (resultContext) => {
+  performContainerTest('bpmnlint', { timeout: 30000, hasOutput: true }, 'bpmnlint', [`--mount type=bind,src=${__dirname},dst=/project`], (resultContext) => {
     it('should run without errors', function () {
       expect(resultContext.error).to.be.null;
     });
@@ -114,7 +114,7 @@ describe('Integration Tests', function () {
     'bpmnlint with custom rules',
     { timeout: 30000, hasOutput: true },
     'bpmnlint',
-    [`--mount type=bind,src=${__dirname},dst=/project`, '-e PROJECT_PATH=/project', `-e BPMN_RULES_PATH=/project/bpmn-rules`],
+    [`--mount type=bind,src=${__dirname},dst=/project`, `-e BPMN_RULES_PATH=/project/bpmn-rules`],
     (resultContext) => {
       it('should run without errors', function () {
         expect(resultContext.error).to.be.null;
@@ -127,7 +127,7 @@ describe('Integration Tests', function () {
   // *****************************************************************
   // dmnlint
   // *****************************************************************
-  performContainerTest('dmnlint', { timeout: 30000, hasOutput: true }, 'dmnlint', [`--mount type=bind,src=${__dirname},dst=/project`, '-e PROJECT_PATH=/project'], (resultContext) => {
+  performContainerTest('dmnlint', { timeout: 30000, hasOutput: true }, 'dmnlint', [`--mount type=bind,src=${__dirname},dst=/project`], (resultContext) => {
     it('should run without errors', function () {
       expect(resultContext.error).to.be.null;
     });
@@ -142,7 +142,7 @@ describe('Integration Tests', function () {
     'dmnlint with custom rules',
     { timeout: 30000, hasOutput: true },
     'dmnlint',
-    [`--mount type=bind,src=${__dirname},dst=/project`, '-e PROJECT_PATH=/project', `-e DMN_RULES_PATH=/project/dmn-rules`],
+    [`--mount type=bind,src=${__dirname},dst=/project`, `-e DMN_RULES_PATH=/project/dmn-rules`],
     (resultContext) => {
       it('should run without errors', function () {
         expect(resultContext.error).to.be.null;
@@ -155,7 +155,7 @@ describe('Integration Tests', function () {
   // *****************************************************************
   // lint
   // *****************************************************************
-  performContainerTest('lint', { timeout: 30000, hasOutput: true }, 'lint', [`--mount type=bind,src=${__dirname},dst=/project`, '-e PROJECT_PATH=/project'], (resultContext) => {
+  performContainerTest('lint', { timeout: 30000, hasOutput: true }, 'lint', [`--mount type=bind,src=${__dirname},dst=/project`], (resultContext) => {
     it('should run without errors', function () {
       expect(resultContext.error).to.be.null;
     });
@@ -174,7 +174,7 @@ describe('Integration Tests', function () {
     'lint with custom bpmn rules',
     { timeout: 30000, hasOutput: true },
     'lint',
-    [`--mount type=bind,src=${__dirname},dst=/project`, '-e PROJECT_PATH=/project', `-e BPMN_RULES_PATH=/project/bpmn-rules`],
+    [`--mount type=bind,src=${__dirname},dst=/project`, `-e BPMN_RULES_PATH=/project/bpmn-rules`],
     (resultContext) => {
       it('should run without errors', function () {
         expect(resultContext.error).to.be.null;
@@ -195,7 +195,7 @@ describe('Integration Tests', function () {
     'lint with custom dmn rules',
     { timeout: 30000, hasOutput: true },
     'lint',
-    [`--mount type=bind,src=${__dirname},dst=/project`, '-e PROJECT_PATH=/project', `-e DMN_RULES_PATH=/project/dmn-rules`],
+    [`--mount type=bind,src=${__dirname},dst=/project`, `-e DMN_RULES_PATH=/project/dmn-rules`],
     (resultContext) => {
       it('should run without errors', function () {
         expect(resultContext.error).to.be.null;
@@ -216,7 +216,7 @@ describe('Integration Tests', function () {
     'lint with custom bpmn and dmn rules',
     { timeout: 30000, hasOutput: true },
     'lint',
-    [`--mount type=bind,src=${__dirname},dst=/project`, '-e PROJECT_PATH=/project', `-e BPMN_RULES_PATH=/project/bpmn-rules`, `-e DMN_RULES_PATH=/project/dmn-rules`],
+    [`--mount type=bind,src=${__dirname},dst=/project`, `-e BPMN_RULES_PATH=/project/bpmn-rules`, `-e DMN_RULES_PATH=/project/dmn-rules`],
     (resultContext) => {
       it('should run without errors', function () {
         expect(resultContext.error).to.be.null;


### PR DESCRIPTION
Tackles #73 and #74:
- Removed the need to use the env vars PROJECT_PATH, BPMN_PATH and DMN_PATH;
- The linter now defaults to always using the working directory;
- Removed global npm installs from the Dockerfile due to their redundancy at this time;
- Removed the `VOLUME /local` as it can cause local host folders to be created if they don't exist. (To clean up your system run `docker volume prune`)
- Changed the `WORKDIR /app` location to reduce the RUN commands used on the Dockerfile
- Updated the build-image to use the working directory and use mount instead of volume for the smoke-test
- Changed the lint.js behavior to use the working directory for the project files
- Changed the lint.js to always provide a default filename for a report output.
- Fixed small reporting issue related to total counts
- Updated the integration tests to use the working directory instead