### PR TITLE
Sanitize branch name before using it as a Docker image tag

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -22,7 +22,25 @@ on:
 jobs:
   build-image:
     runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.tag.outputs.tag }}
     steps:
+      # Branch names may contain characters a Docker tag cannot (most commonly '/'),
+      # so map them onto the tag grammar: [a-zA-Z0-9_][a-zA-Z0-9._-]{0,127}
+      - name: Derive image tag from branch name
+        id: tag
+        env:
+          RAW_BRANCH: ${{ inputs.branch-name }}
+        run: |
+          tag=$(printf '%s' "$RAW_BRANCH" | sed -E 's/[^a-zA-Z0-9._-]+/-/g; s/^[^a-zA-Z0-9_]+//')
+          tag=${tag:0:128}
+          if [ -z "$tag" ]; then tag=branch; fi
+          echo "Branch '$RAW_BRANCH' -> image tag '$tag'"
+          # Both writes are needed: GITHUB_OUTPUT crosses to the test-image job,
+          # GITHUB_ENV serves the remaining steps in this job.
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "IMAGE_TAG=$tag" >> "$GITHUB_ENV"
+
       - name: Checkout repository
         uses: actions/checkout@v4
 
@@ -67,7 +85,7 @@ jobs:
             exit 0
           fi
 
-          id=$(jq -r ".[] | select(.metadata.container.tags | index(\"${{ inputs.branch-name }}\")) | .id" "${json_response_file}")
+          id=$(jq -r --arg tag "$IMAGE_TAG" '.[] | select(.metadata.container.tags | index($tag)) | .id' "${json_response_file}")
 
           if [ "$id" != "" ]; then
             # First call is just to see the result
@@ -86,17 +104,23 @@ jobs:
       - name: Build Docker image of application, tag with branch name
         env:
           NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          IMAGE: ${{ inputs.image-name }}
         run: |
-          echo "image-name = ${{ inputs.image-name }}"
-          echo "branch-name = ${{ inputs.branch-name}}"
-          docker build --secret id=GH_TOKEN,env=NPM_TOKEN -t ${{ inputs.image-name }}:${{ inputs.branch-name }} .
+          echo "image-name = $IMAGE"
+          echo "image-tag  = $IMAGE_TAG"
+          docker build --secret id=GH_TOKEN,env=NPM_TOKEN -t "$IMAGE:$IMAGE_TAG" .
 
       - name: Push to local registry
+        env:
+          IMAGE: ${{ inputs.image-name }}
         run: |
-          docker push ${{ inputs.image-name }}:${{ inputs.branch-name }}
+          docker push "$IMAGE:$IMAGE_TAG"
   test-image:
     runs-on: ubuntu-latest
     needs: build-image
+    env:
+      # Derived once in build-image; job-level env makes it visible to every step below.
+      IMAGE_TAG: ${{ needs.build-image.outputs.tag }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -121,22 +145,28 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Pull the image
+        env:
+          IMAGE: ${{ inputs.image-name }}
         run: |
-          docker pull ${{ inputs.image-name }}:${{ inputs.branch-name }}
+          docker pull "$IMAGE:$IMAGE_TAG"
 
       - name: Run Smoke Test
+        env:
+          IMAGE: ${{ inputs.image-name }}
         run: |
           docker run -i --rm \
             --mount type=bind,src=${PWD}/test/smoke-test,dst=/project \
-            ${{ inputs.image-name }}:${{ inputs.branch-name }} lint
+            "$IMAGE:$IMAGE_TAG" lint
 
       - name: Run Integration Tests
         env:
           IMAGE_NAME: ${{ inputs.image-name }}
-          BRANCH_NAME: ${{ inputs.branch-name }}
+          BRANCH_NAME: ${{ env.IMAGE_TAG }}
         run: |
           npm run test:integration
 
 #      - name: Run SBOM Test
+#        env:
+#          IMAGE: ${{ inputs.image-name }}
 #        run: |
-#          docker run -i --rm ${{ inputs.image-name }}:${{ inputs.branch-name }} sbom
+#          docker run -i --rm "$IMAGE:$IMAGE_TAG" sbom


### PR DESCRIPTION
Docker tags must match [a-zA-Z0-9_][a-zA-Z0-9._-]{0,127}, so a branch containing '/' produced an unparseable reference and failed the build:

  invalid tag "ghcr.io/bp3/camunda-lint:feature/renovate":
  invalid reference format

Every branch so far has been flat, so this went unnoticed until feature/renovate branch was added. 

build-image now derives the tag once and publishes it as a job output; test-image consumes it via job-level env, so there is a single derivation and the two jobs cannot disagree.