### PR TITLE
Add a workflow to purge old package versions from ghcr.io

### DIFF
--- a/.github/workflows/purge-packages.yml
+++ b/.github/workflows/purge-packages.yml
@@ -1,0 +1,48 @@
+name: Purge old package versions
+
+on:
+  schedule:
+    - cron: '0 3 * * 0' # weekly, Sunday 03:00 UTC
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: 'Log what would be deleted, without deleting it'
+        type: boolean
+        default: true
+
+# The cleanup action is not safe to run in parallel against the same package.
+concurrency:
+  group: purge-packages
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  purge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Purge old versions of the container package
+        uses: dataaxiom/ghcr-cleanup-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          owner: bp3
+          packages: camunda-lint
+
+          # main is load-bearing - release.yml pulls it to cut every release.
+          use-regex: true
+          exclude-tags: '^(main|latest|built-test|v?[0-9]+\.[0-9]+\.[0-9]+.*)$'
+
+          # Keep the 15 newest branch-build images, delete the rest. Excluded
+          # tags above do not consume these slots.
+          keep-n-tagged: 15
+
+          # Reclaim digests orphaned when a branch tag was moved to a new build.
+          delete-untagged: true
+          delete-ghost-images: true
+
+          validate: true
+          # Undefined on the schedule trigger, so the cron deletes for real
+          # while a manual run defaults to a preview.
+          dry-run: ${{ inputs.dry-run == true }}


### PR DESCRIPTION
Nothing reclaims container versions in ghcr.io/bp3/camunda-lint, so it accumulates one image per merged/abandoned PR branch plus every digest orphaned when a branch tag moves. The delete step in build-image.yml only matches the exact tag it is about to re-push, so it never sees untagged versions.

Runs weekly on Sunday 03:00 UTC and on demand, keeping the 15 newest branch-build images and reclaiming untagged and ghost digests.

Uses dataaxiom/ghcr-cleanup-action rather than the actions/delete-package- versions suggested in the issue. That action matches ignore-versions against the package version name, which for a GHCR container is the sha256 digest and not the tag, so ignore-versions: 'main' protects nothing (upstream issues #88, #104 and #121, all still open). Combined with min-versions-to-keep, which keeps the newest by date, it would have deleted the published releases 0.1.2, 0.1.1, 0.1.0 and 0.0.4 along with main. Here exclude-tags matches real tags and is applied before any keep/delete rule, so those tags cannot be deleted by any later rule and do not consume keep-n-tagged slots.

Refs #98