### PR TITLE
Replace chalk with Node's util.styleText()

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: '>=22.14.0'
+          node-version: '>=22.15.0'
       - name: Install dependencies
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/lint-runner.js
+++ b/lint-runner.js
@@ -17,7 +17,7 @@ const fs = require('fs');
 const path = require('path');
 const junitReportBuilder = require('junit-report-builder');
 const { execSync } = require('child_process');
-const chalk = require('chalk');
+const { styleText } = require('util');
 const { logger } = require('./logger');
 
 const { Linter: BpmnLinter } = require('bpmnlint');
@@ -300,10 +300,10 @@ function generateReport({ allIssues, totalErrors, totalWarnings }, lintedFiles, 
   let reportDetails = '';
 
   const theme = {
-    error: chalk.red(' ❌ Error'),
-    warn: chalk.yellow(' ⚠️ Warning'),
-    warning: chalk.yellow(' ⚠️ Warning'),
-    info: chalk.blueBright(` ℹ️ Info`),
+    error: styleText('red', ' ❌ Error'),
+    warn: styleText('yellow', ' ⚠️ Warning'),
+    warning: styleText('yellow', ' ⚠️ Warning'),
+    info: styleText('blueBright', ` ℹ️ Info`),
   };
 
   if (showConsoleTable && allIssues.length > 0) {
@@ -315,7 +315,7 @@ function generateReport({ allIssues, totalErrors, totalWarnings }, lintedFiles, 
       const file = path.basename(issue.file);
       const output = isError ? totalErrors > 0 : totalErrors === 0;
       if (output) {
-        reportDetails += `${label} ${chalk.cyan(file)} › ${issue.id || 'N/A'}: ${issue.message} ${chalk.gray(`(${issue.rule})`)}\n`;
+        reportDetails += `${label} ${styleText('cyan', file)} › ${issue.id || 'N/A'}: ${issue.message} ${styleText('gray', `(${issue.rule})`)}\n`;
       }
     });
   } else {
@@ -324,8 +324,8 @@ function generateReport({ allIssues, totalErrors, totalWarnings }, lintedFiles, 
 
   // Footer Summary
   logger.info(`
-${chalk.gray('-'.repeat(60))}
-${chalk.bold('LINT RESULTS')} | Files: ${lintedFiles.length} | Errors: ${chalk.red.bold(totalErrors)} | Warnings: ${chalk.yellow.bold(totalWarnings)}`);
+${styleText('gray', '-'.repeat(60))}
+${styleText('bold', 'LINT RESULTS')} | Files: ${lintedFiles.length} | Errors: ${styleText(['red', 'bold'], String(totalErrors))} | Warnings: ${styleText(['yellow', 'bold'], String(totalWarnings))}`);
 
   const extension = format === 'junit' ? 'xml' : format;
   const finalOutputPath = path.resolve(

--- a/logger.js
+++ b/logger.js
@@ -12,7 +12,7 @@
  =
  =================================================================================*/
 
-const chalk = require('chalk');
+const { styleText } = require('util');
 const process = require('process');
 
 const LOG_LEVELS = {
@@ -36,22 +36,22 @@ function isLogLevelEnabled(logLevel) {
 const logger = {
   debug: (...args) => {
     if (isLogLevelEnabled(LOG_LEVELS.debug)) {
-      console.log(chalk.gray('DEBUG:'), ...args);
+      console.log(styleText('gray', 'DEBUG:'), ...args);
     }
   },
   info: (...args) => {
     if (isLogLevelEnabled(LOG_LEVELS.info)) {
-      console.log(chalk.blueBright.bold('INFO:'), ...args);
+      console.log(styleText(['blueBright', 'bold'], 'INFO:'), ...args);
     }
   },
   warn: (...args) => {
     if (isLogLevelEnabled(LOG_LEVELS.warn)) {
-      console.warn(chalk.yellowBright.bold('WARN:'), ...args);
+      console.warn(styleText(['yellowBright', 'bold'], 'WARN:', { stream: process.stderr }), ...args);
     }
   },
   error: (...args) => {
     if (isLogLevelEnabled(LOG_LEVELS.error)) {
-      console.error(chalk.redBright.bold('ERROR:'), ...args);
+      console.error(styleText(['redBright', 'bold'], 'ERROR:', { stream: process.stderr }), ...args);
     }
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
         "bpmnlint-plugin-bp3-dynamic-rules": "file:bp3-dynamic-rules",
         "bpmnlint-plugin-camunda-compat": "^2.49.0",
         "bpmnlint-utils": "^1.1.1",
-        "chalk": "^4.1.2",
         "dmn-moddle": "^12.0.1",
         "dmnlint": "^0.2.0",
         "dmnlint-plugin-bp3-dynamic-rules": "file:bp3-dynamic-rules",
@@ -40,7 +39,7 @@
         "prettier": "^3.6.2"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22.15.0"
       }
     },
     "bp3-dynamic-rules": {
@@ -500,6 +499,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -680,6 +680,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -789,6 +790,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -801,6 +803,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/color-support": {
@@ -974,11 +977,82 @@
       "integrity": "sha512-6GqnqfTaVj7ZZOa8bump7IjKbzvSVtb8b8aZZdIDaW7FH5/jBuPEFtpv9Ug+tkE4upRmIigCYvGMInHE/iLy+Q==",
       "license": "MIT"
     },
+    "node_modules/dmnlint/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/dmnlint/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/dmnlint/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/dmnlint/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "license": "MIT"
+    },
+    "node_modules/dmnlint/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/dmnlint/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/dmnlint/node_modules/pluralize": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
       "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
       "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/dmnlint/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
       "engines": {
         "node": ">=4"
       }
@@ -1483,6 +1557,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2700,6 +2775,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "sbom": "npx @cyclonedx/cyclonedx-npm -o camunda-lint-sbom.json"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=22.15.0"
   },
   "dependencies": {
     "bp3-dynamic-rules": "file:bp3-dynamic-rules",
@@ -27,7 +27,6 @@
     "bpmnlint-plugin-bp3-dynamic-rules": "file:bp3-dynamic-rules",
     "bpmnlint-plugin-camunda-compat": "^2.49.0",
     "bpmnlint-utils": "^1.1.1",
-    "chalk": "^4.1.2",
     "dmn-moddle": "^12.0.1",
     "dmnlint": "^0.2.0",
     "dmnlint-plugin-bp3-dynamic-rules": "file:bp3-dynamic-rules",
@@ -54,7 +53,6 @@
     "dmnlint": "$dmnlint",
     "dmnlint-utils": "$dmnlint-utils",
     "zeebe-bpmn-moddle": "$zeebe-bpmn-moddle",
-    "chalk": "$chalk",
     "cli-table3": "$cli-table3",
     "junit-report-builder": "$junit-report-builder",
     "tiny-glob": "$tiny-glob",


### PR DESCRIPTION
Drops chalk as a direct dependency in favour of the built-in util.styleText()
API, and removes its entry from the overrides block along with it.

styleText() throws on non-string input where chalk coerced, so the error and
warning counts in the summary footer are now stringified explicitly.

engines.node moves from >=20 to >=22.15.0. Passing an array of formats to
styleText() only honours the stream colour check from 22.15.0 onward; on earlier
releases that code path returns before the check, leaking escape codes into
piped and redirected output. CI's setup-node floor moves in step.

Closes #106