### PR TITLE
Allow Dependabot PRs to push the branch image to ghcr.io

### DIFF
--- a/.github/workflows/branch-build.yml
+++ b/.github/workflows/branch-build.yml
@@ -15,6 +15,12 @@ jobs:
 
   call-workflow-build-image:
     needs: lint
+    # Dependabot-triggered pull_request runs default to a read-only GITHUB_TOKEN,
+    # which fails the ghcr.io push. Naming the scopes explicitly restores the
+    # write that the push and the branch-tag cleanup need.
+    permissions:
+      contents: read
+      packages: write
     uses: ./.github/workflows/build-image.yml
     with:
       username: ${{ github.actor }}


### PR DESCRIPTION
GitHub treats workflow runs triggered by Dependabot from push and pull_request events as if they came from a fork, so GITHUB_TOKEN defaults to read-only. branch-build.yml declared no permissions at all and relied on the repository's read-write default, which Dependabot overrides. The docker push in build-image.yml therefore failed on PR #110 while the same step succeeds from main-build.yml.

Read-only is the default rather than a ceiling: Dependabot-triggered runs have respected the permissions key since October 2021. Naming the scopes on the calling job restores the write that the push and the branch-tag cleanup need, and passes through to the reusable workflow, whose test-image job covers its docker pull under packages:write.

Set on the job rather than the workflow so the lint job keeps the read-only default, which is all it needs.